### PR TITLE
:bug: Fix fetch span from stack

### DIFF
--- a/src/Bridge/RequestSpanListener.php
+++ b/src/Bridge/RequestSpanListener.php
@@ -82,7 +82,7 @@ class RequestSpanListener implements EventSubscriberInterface
 
         $exception = $event->getThrowable();
 
-        $this->spans->current()
+        $this->spans->top()
             ->addTag(new ErrorTag())
             ->addLog(new ErrorLog($exception->getMessage(), $exception->getTraceAsString()))
         ;


### PR DESCRIPTION
`current()` is not working without `rewind()/next()/etc...`

> Call to a member function `addTag()` on null

See: https://www.php.net/manual/ru/spldoublylinkedlist.current.php#102106