### PR TITLE
Deprecation free

### DIFF
--- a/src/Bridge/AppStartSpanListener.php
+++ b/src/Bridge/AppStartSpanListener.php
@@ -8,6 +8,7 @@ use Jaeger\Symfony\Tag\SymfonyVersionTag;
 use Jaeger\Tag\SpanKindServerTag;
 use Jaeger\Tracer\TracerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 class AppStartSpanListener implements EventSubscriberInterface
@@ -27,7 +28,7 @@ class AppStartSpanListener implements EventSubscriberInterface
     public function onRequest(RequestEvent $event)
     {
         $request = $event->getRequest();
-        if (false === $event->isMasterRequest()) {
+        if (false === $this->isMainRequestEvent($event)) {
             return $this;
         }
         $this->tracer
@@ -39,5 +40,21 @@ class AppStartSpanListener implements EventSubscriberInterface
             ->finish();
 
         return $this;
+    }
+
+    /**
+     * Use non-deprecated check method if availble
+     *
+     * @param KernelEvent $event
+     *
+     * @return bool
+     */
+    private function isMainRequestEvent(KernelEvent $event): bool
+    {
+        if (\method_exists($event, 'isMainRequest')) {
+            return $event->isMainRequest();
+        }
+
+        return $event->isMasterRequest();
     }
 }

--- a/src/Bridge/ContextListener.php
+++ b/src/Bridge/ContextListener.php
@@ -7,6 +7,7 @@ use Jaeger\Symfony\Context\Extractor\ContextExtractorInterface;
 use Jaeger\Tracer\InjectableInterface;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 class ContextListener implements EventSubscriberInterface
@@ -46,9 +47,25 @@ class ContextListener implements EventSubscriberInterface
 
     public function onRequest(RequestEvent $event): void
     {
-        if (false === $event->isMasterRequest()) {
+        if (false === $this->isMainRequestEvent($event)) {
             return;
         }
         $this->inject();
+    }
+
+    /**
+     * Use non-deprecated check method if availble
+     *
+     * @param KernelEvent $event
+     *
+     * @return bool
+     */
+    private function isMainRequestEvent(KernelEvent $event): bool
+    {
+        if (\method_exists($event, 'isMainRequest')) {
+            return $event->isMainRequest();
+        }
+
+        return $event->isMasterRequest();
     }
 }

--- a/src/Bridge/DebugListener.php
+++ b/src/Bridge/DebugListener.php
@@ -8,6 +8,7 @@ use Jaeger\Tracer\DebuggableInterface;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
@@ -48,12 +49,28 @@ class DebugListener implements EventSubscriberInterface
 
     public function onRequest(RequestEvent $event)
     {
-        if (false === $event->isMasterRequest()) {
+        if (false === $this->isMainRequestEvent($event)) {
             return;
         }
         if ('' === ($debugId = $this->extractor->getDebug())) {
             return;
         }
         $this->debuggable->enable($debugId);
+    }
+
+    /**
+     * Use non-deprecated check method if availble
+     *
+     * @param KernelEvent $event
+     *
+     * @return bool
+     */
+    private function isMainRequestEvent(KernelEvent $event): bool
+    {
+        if (\method_exists($event, 'isMainRequest')) {
+            return $event->isMainRequest();
+        }
+
+        return $event->isMasterRequest();
     }
 }

--- a/src/Bridge/GlobalSpanListener.php
+++ b/src/Bridge/GlobalSpanListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Jaeger\Symfony\Bridge;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
@@ -33,11 +34,27 @@ class GlobalSpanListener implements EventSubscriberInterface
 
     public function onRequest(RequestEvent $event)
     {
-        if (false === $event->isMasterRequest()) {
+        if (false === $this->isMainRequestEvent($event)) {
             return $this;
         }
         $this->handler->start($event->getRequest());
 
         return $this;
+    }
+
+    /**
+     * Use non-deprecated check method if availble
+     *
+     * @param KernelEvent $event
+     *
+     * @return bool
+     */
+    private function isMainRequestEvent(KernelEvent $event): bool
+    {
+        if (\method_exists($event, 'isMainRequest')) {
+            return $event->isMainRequest();
+        }
+
+        return $event->isMasterRequest();
     }
 }

--- a/src/Debug/Extractor/CookieDebugExtractor.php
+++ b/src/Debug/Extractor/CookieDebugExtractor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Jaeger\Symfony\Debug\Extractor;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
@@ -20,7 +21,7 @@ class CookieDebugExtractor implements DebugExtractorInterface, EventSubscriberIn
 
     public function onRequest(RequestEvent $event): void
     {
-        if (false === $event->isMasterRequest()) {
+        if (false === $this->isMainRequestEvent($event)) {
             return;
         }
         $request = $event->getRequest();
@@ -32,7 +33,7 @@ class CookieDebugExtractor implements DebugExtractorInterface, EventSubscriberIn
 
     public function onTerminate(TerminateEvent $event): void
     {
-        if (false === $event->isMasterRequest()) {
+        if (false === $this->isMainRequestEvent($event)) {
             return;
         }
         $this->debugId = '';
@@ -49,5 +50,21 @@ class CookieDebugExtractor implements DebugExtractorInterface, EventSubscriberIn
             RequestEvent::class => ['onRequest', 16384],
             TerminateEvent::class => ['onTerminate'],
         ];
+    }
+
+    /**
+     * Use non-deprecated check method if availble
+     *
+     * @param KernelEvent $event
+     *
+     * @return bool
+     */
+    private function isMainRequestEvent(KernelEvent $event): bool
+    {
+        if (\method_exists($event, 'isMainRequest')) {
+            return $event->isMainRequest();
+        }
+
+        return $event->isMasterRequest();
     }
 }

--- a/src/DependencyInjection/DeprecatedAliasesCompilerPass.php
+++ b/src/DependencyInjection/DeprecatedAliasesCompilerPass.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Jaeger\Symfony\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Dumper\Preloader;
+
+class DeprecatedAliasesCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $container->getAlias('jaeger.span.handler.gloabal')
+            ->setDeprecated(
+                ...
+                $this->getDeprecationMsg(
+                    'The "%alias_id%" service is deprecated. Use "jaeger.span.handler.global".',
+                    '3.5.0'
+                )
+            );
+    }
+
+    /**
+     * Returns the correct deprecation param's as an array for setDeprecated.
+     *
+     * symfony/dependency-injection v5.1 introduces a deprecation notice when calling
+     * setDeprecation() with less than 3 args and the
+     * `Symfony\Component\DependencyInjection\Dumper\Preloader` class was
+     * introduced at the same time. By checking if this class exists,
+     * we can determine the correct param count to use when calling setDeprecated.
+     *
+     * @param string $message
+     * @param string $version
+     *
+     * @return array
+     */
+    private function getDeprecationMsg(string $message, string $version): array
+    {
+        if (class_exists(Preloader::class)) {
+            return [
+                'code-tool/jaeger-client-symfony-bridge',
+                $version,
+                $message,
+            ];
+        }
+
+        return [$message];
+    }
+}

--- a/src/JaegerBundle.php
+++ b/src/JaegerBundle.php
@@ -6,6 +6,7 @@ namespace Jaeger\Symfony;
 use Jaeger\Symfony\DependencyInjection\CodecRegistryCompilerPass;
 use Jaeger\Symfony\DependencyInjection\ContextExtractorChainCompilerPass;
 use Jaeger\Symfony\DependencyInjection\DebugExtractorChainCompilerPass;
+use Jaeger\Symfony\DependencyInjection\DeprecatedAliasesCompilerPass;
 use Jaeger\Symfony\DependencyInjection\NameGeneratorChainCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -19,6 +20,7 @@ class JaegerBundle extends Bundle
             ->addCompilerPass(new CodecRegistryCompilerPass())
             ->addCompilerPass(new ContextExtractorChainCompilerPass())
             ->addCompilerPass(new DebugExtractorChainCompilerPass())
-            ->addCompilerPass(new NameGeneratorChainCompilerPass());
+            ->addCompilerPass(new NameGeneratorChainCompilerPass())
+            ->addCompilerPass(new DeprecatedAliasesCompilerPass());
     }
 }

--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -139,9 +139,6 @@ services:
   jaeger.span.handler.background:
     class: Jaeger\Symfony\Bridge\BackgroundSpanHandler
     arguments: ['@jaeger.tracer']
-  jaeger.span.handler.gloabal:
-    alias: jaeger.span.handler.global
-    deprecated: 'The "%alias_id%" service is deprecated. Use "jaeger.span.handler.global".'
   jaeger.span.handler.global:
     class: Jaeger\Symfony\Bridge\GlobalSpanHandler
     arguments: ['@jaeger.tracer', '@jaeger.name.generator']
@@ -198,3 +195,7 @@ services:
       - '@jaeger.span.manager'
     tags:
       - {name: 'kernel.event_subscriber'}
+  # deprecated since 3.5.0
+  jaeger.span.handler.gloabal:
+    alias: jaeger.span.handler.global
+


### PR DESCRIPTION
Resolve deprecations:
1) The signature of method "Symfony\Component\DependencyInjection\Alias::setDeprecated()" requires 3 arguments (since symfony/dependency-injection 5.1)
2) "isMasterRequest()" is deprecated, use "isMainRequest()" instead. https://github.com/symfony/symfony/pull/40536 (since symfony/http-kernel 5.3)