### PR TITLE
128 trace id support from the jaeger-client-php library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   },
   "require": {
     "php": ">=7.4",
-    "code-tool/jaeger-client-php": "^3.1",
+    "code-tool/jaeger-client-php": "^3.4",
     "symfony/config": "^4.3|^5.0",
     "symfony/console": "^4.3|^5.0",
     "symfony/dependency-injection": "^4.3|^5.0",

--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -12,6 +12,7 @@ parameters:
   env(JAEGER_DEBUG_COOKIE): 'debug'
   env(JAEGER_SERVICE_NAME): '%service_name%'
   env(JAEGER_SPAN_BATCH): '16'
+  env(JAEGER_TRACE_128): '%env(bool:JAEGER_TRACE_128)%'
 
 services:
   spl.stack:
@@ -41,7 +42,7 @@ services:
     arguments: ['%env(JAEGER_SAMPLER_TYPE)%', '%env(JAEGER_SAMPLER_PARAM)%']
   jaeger.span.factory:
     class: Jaeger\Span\Factory\SpanFactory
-    arguments: ['@id.generator.span', '@jaeger.sampler']
+    arguments: ['@id.generator.span', '@jaeger.sampler', '%env(bool:JAEGER_TRACE_128)%']
   client.thrift:
     class: Jaeger\Client\ThriftClient
     arguments: ['%env(JAEGER_SERVICE_NAME)%', '@thrift.agent', '%env(JAEGER_SPAN_BATCH)%']

--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -12,7 +12,7 @@ parameters:
   env(JAEGER_DEBUG_COOKIE): 'debug'
   env(JAEGER_SERVICE_NAME): '%service_name%'
   env(JAEGER_SPAN_BATCH): '16'
-  env(JAEGER_TRACE_128): '%env(bool:JAEGER_TRACE_128)%'
+  env(JAEGER_TRACE_128): false
 
 services:
   spl.stack:


### PR DESCRIPTION
Controllable through JAEGER_TRACE_128 env variable