### PR TITLE
Default env variable value should be a string

### DIFF
--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -12,7 +12,7 @@ parameters:
   env(JAEGER_DEBUG_COOKIE): 'debug'
   env(JAEGER_SERVICE_NAME): '%service_name%'
   env(JAEGER_SPAN_BATCH): '16'
-  env(JAEGER_TRACE_128): false
+  env(JAEGER_TRACE_128): '0'
 
 services:
   spl.stack:


### PR DESCRIPTION
Since Symfony 4.3 it is deprecated to use any non-string value for default env variable value
https://github.com/symfony/symfony/pull/27808