### PR TITLE
Fix symfony.start span pos by changing eventListeners order

### DIFF
--- a/src/Bridge/AppStartSpanListener.php
+++ b/src/Bridge/AppStartSpanListener.php
@@ -22,7 +22,7 @@ class AppStartSpanListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents(): array
     {
-        return [RequestEvent::class => ['onRequest', 25],];
+        return [RequestEvent::class => ['onRequest', -1023],];
     }
 
     public function onRequest(RequestEvent $event)

--- a/src/Bridge/AppStartSpanListener.php
+++ b/src/Bridge/AppStartSpanListener.php
@@ -22,21 +22,21 @@ class AppStartSpanListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents(): array
     {
-        return [RequestEvent::class => ['onRequest', -1],];
+        return [RequestEvent::class => ['onRequest', 25],];
     }
 
     public function onRequest(RequestEvent $event)
     {
-        $request = $event->getRequest();
         if (false === $this->isMainRequestEvent($event)) {
             return $this;
         }
+
         $this->tracer
             ->start('symfony.start')
             ->addTag(new SpanKindServerTag())
             ->addTag(new SymfonyComponentTag())
             ->addTag(new SymfonyVersionTag())
-            ->start((int)(1000000 * $request->server->get('REQUEST_TIME_FLOAT', microtime(true))))
+            ->start((int)(1000000 * $event->getRequest()->server->get('REQUEST_TIME_FLOAT', microtime(true))))
             ->finish();
 
         return $this;

--- a/src/Bridge/GlobalSpanListener.php
+++ b/src/Bridge/GlobalSpanListener.php
@@ -20,7 +20,7 @@ class GlobalSpanListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            RequestEvent::class => ['onRequest', 30],
+            RequestEvent::class => ['onRequest', 25],
             TerminateEvent::class => ['onTerminate', 4096],
         ];
     }

--- a/src/Bridge/RequestSpanListener.php
+++ b/src/Bridge/RequestSpanListener.php
@@ -37,7 +37,7 @@ class RequestSpanListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            RequestEvent::class => ['onRequest', -1],
+            RequestEvent::class => ['onRequest', -1024],
             ResponseEvent::class => ['onResponse', -1024],
             ExceptionEvent::class => ['onKernelException', 0],
         ];

--- a/src/Bridge/RequestSpanListener.php
+++ b/src/Bridge/RequestSpanListener.php
@@ -37,7 +37,7 @@ class RequestSpanListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            RequestEvent::class => ['onRequest', 0],
+            RequestEvent::class => ['onRequest', -1],
             ResponseEvent::class => ['onResponse', -1024],
             ExceptionEvent::class => ['onKernelException', 0],
         ];

--- a/src/Bridge/RequestSpanListener.php
+++ b/src/Bridge/RequestSpanListener.php
@@ -37,7 +37,7 @@ class RequestSpanListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            RequestEvent::class => ['onRequest', 29],
+            RequestEvent::class => ['onRequest', 0],
             ResponseEvent::class => ['onResponse', -1024],
             ExceptionEvent::class => ['onKernelException', 0],
         ];

--- a/src/Name/Generator/ControllerNameGenerator.php
+++ b/src/Name/Generator/ControllerNameGenerator.php
@@ -15,7 +15,7 @@ class ControllerNameGenerator implements NameGeneratorInterface, EventSubscriber
     {
         return [
             // Subscribe after route was resolved and request attributes were set
-            RequestEvent::class => ['onRequest', 31],
+            RequestEvent::class => ['onRequest', 30],
             TerminateEvent::class => ['onTerminate', -16384],
         ];
     }

--- a/src/Name/Generator/DefaultNameGenerator.php
+++ b/src/Name/Generator/DefaultNameGenerator.php
@@ -17,7 +17,7 @@ class DefaultNameGenerator implements NameGeneratorInterface, EventSubscriberInt
     {
         return [
             // Subscribe after route was resolved and request attributes were set
-            RequestEvent::class => ['onRequest', 31],
+            RequestEvent::class => ['onRequest', 30],
             ConsoleCommandEvent::class => ['onCommand', 31],
             TerminateEvent::class => ['onTerminate', -16384],
             ConsoleTerminateEvent::class => ['onTerminate'],

--- a/src/Name/Generator/RequestNameGenerator.php
+++ b/src/Name/Generator/RequestNameGenerator.php
@@ -35,7 +35,7 @@ class RequestNameGenerator implements NameGeneratorInterface, EventSubscriberInt
     {
         return [
             // Subscribe after route was resolved and request attributes were set
-            RequestEvent::class => ['onRequest', 31],
+            RequestEvent::class => ['onRequest', 30],
             TerminateEvent::class => ['onTerminate', -16384],
         ];
     }


### PR DESCRIPTION
Before
```
 ------- ----------------------------------------------------------------------------------------------------- ---------- 
  Order   Callable                                                                                              Priority  
 ------- ----------------------------------------------------------------------------------------------------- ---------- 
  #1      Jaeger\Symfony\Context\Extractor\HeaderContextExtractor::onRequest()                                  16384     
  #2      Jaeger\Symfony\Debug\Extractor\CookieDebugExtractor::onRequest()                                      16384     
  #3      Jaeger\Symfony\Bridge\DebugListener::onRequest()                                                      8192      
  #4      Jaeger\Symfony\Bridge\ContextListener::onRequest()                                                    8192      
  #5      Proprietary::onRequest()                                                                              8192      
  #6      Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::configure()                         2048      
  #7      Symfony\Component\HttpKernel\EventListener\ValidateRequestListener::onKernelRequest()                 256       
  #8      Qandidate\Common\Symfony\HttpKernel\EventListener\JsonRequestTransformerListener::onKernelRequest()   100       
  #9      Symfony\Component\HttpKernel\EventListener\LocaleListener::setDefaultLocale()                         100       
  #10     Symfony\Component\HttpKernel\EventListener\RouterListener::onKernelRequest()                          32        
  #11     Jaeger\Symfony\Name\Generator\ControllerNameGenerator::onRequest()                                    31        
  #12     Jaeger\Symfony\Name\Generator\DefaultNameGenerator::onRequest()                                       31        
  #13     Jaeger\Symfony\Name\Generator\RequestNameGenerator::onRequest()                                       31        
  #14     Jaeger\Symfony\Bridge\GlobalSpanListener::onRequest()                                                 30        
  #15     Jaeger\Symfony\Bridge\RequestSpanListener::onRequest()                                                29        
  #16     Symfony\Component\HttpKernel\EventListener\LocaleListener::onKernelRequest()                          16        
  #17     Symfony\Component\HttpKernel\EventListener\LocaleAwareListener::onKernelRequest()                     15        
  #18     Jaeger\Symfony\Bridge\AppStartSpanListener::onRequest()                                               -1        
 ------- ----------------------------------------------------------------------------------------------------- ---------- 

```


after
```
 ------- ----------------------------------------------------------------------------------------------------- ---------- 
  Order   Callable                                                                                              Priority  
 ------- ----------------------------------------------------------------------------------------------------- ---------- 
  #1      Jaeger\Symfony\Context\Extractor\HeaderContextExtractor::onRequest()                                  16384     
  #2      Jaeger\Symfony\Debug\Extractor\CookieDebugExtractor::onRequest()                                      16384     
  #3      Jaeger\Symfony\Bridge\DebugListener::onRequest()                                                      8192      
  #4      Jaeger\Symfony\Bridge\ContextListener::onRequest()                                                    8192      
  #5      Proprietary::onRequest()                                                                              8192      
  #6      Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::configure()                         2048      
  #7      Symfony\Component\HttpKernel\EventListener\ValidateRequestListener::onKernelRequest()                 256       
  #8      Qandidate\Common\Symfony\HttpKernel\EventListener\JsonRequestTransformerListener::onKernelRequest()   100       
  #9      Symfony\Component\HttpKernel\EventListener\LocaleListener::setDefaultLocale()                         100       
  #10     Symfony\Component\HttpKernel\EventListener\RouterListener::onKernelRequest()                          32        
  #11     Jaeger\Symfony\Name\Generator\ControllerNameGenerator::onRequest()                                    30        
  #12     Jaeger\Symfony\Name\Generator\DefaultNameGenerator::onRequest()                                       30        
  #13     Jaeger\Symfony\Name\Generator\RequestNameGenerator::onRequest()                                       30        
  #14     Jaeger\Symfony\Bridge\GlobalSpanListener::onRequest()                                                 25        
  #15     Symfony\Component\HttpKernel\EventListener\LocaleListener::onKernelRequest()                          16        
  #16     Symfony\Component\HttpKernel\EventListener\LocaleAwareListener::onKernelRequest()                     15        
  #17     Jaeger\Symfony\Bridge\AppStartSpanListener::onRequest()                                               -1023     
  #18     Jaeger\Symfony\Bridge\RequestSpanListener::onRequest()                                                -1024     
 ------- ----------------------------------------------------------------------------------------------------- ---------- 

```
