### PR TITLE
Introduce SA checks with vime/psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
     "symfony/http-kernel": "^4.4|^5.4|^6.0",
     "symfony/yaml": "^4.4|^5.4|^6.0"
   },
+  "require-dev": {
+    "vimeo/psalm": "^5.15"
+  },
   "minimum-stability": "dev",
   "prefer-stable": true
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+    phpVersion="8.1" used to avoid `ReservedWord` issues with installed Symfony 6+ packages (which required 8.1).
+    Probably there existent another easy workaround, but we didn't find it yet.
+ -->
+<!--suppress XmlDefaultAttributeValue Psalm emits warning: "findUnusedCode" will default to "true" in Psalm 6. You should explicitly enable or disable this setting. -->
+<psalm
+    errorLevel="6"
+    phpVersion="8.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <UndefinedMethod>
+            <errorLevel type="suppress">
+                <!-- BC layer for Symfony 4.4 -->
+                <referencedMethod name="Symfony\Component\HttpKernel\Event\KernelEvent::isMasterRequest" />
+
+                <!-- Psalm doesn't know about type-system of `symfony/config` -->
+                <file name="src/DependencyInjection/Configuration.php"/>
+            </errorLevel>
+        </UndefinedMethod>
+    </issueHandlers>
+</psalm>

--- a/src/Context/Extractor/EnvContextExtractor.php
+++ b/src/Context/Extractor/EnvContextExtractor.php
@@ -12,9 +12,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class EnvContextExtractor implements ContextExtractorInterface, EventSubscriberInterface
 {
-    /**
-     * @var CodecInterface[]
-     */
     private $registry;
 
     private $format;

--- a/src/Context/Extractor/HeaderContextExtractor.php
+++ b/src/Context/Extractor/HeaderContextExtractor.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Jaeger\Symfony\Context\Extractor;
 
-use Jaeger\Codec\CodecInterface;
 use Jaeger\Codec\CodecRegistry;
 use Jaeger\Span\Context\SpanContext;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -13,9 +12,6 @@ use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 class HeaderContextExtractor implements ContextExtractorInterface, EventSubscriberInterface
 {
-    /**
-     * @var CodecInterface[]
-     */
     private $registry;
 
     private $format;


### PR DESCRIPTION
```bash
$ vendor/bin/psalm 
Target PHP version: 8.1 (set by config file).
Scanning files...
Analyzing files...

░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

------------------------------
                              
       No errors found!       
                              
------------------------------
27 other issues found.
You can display them with --show-info=true
------------------------------
Psalm can automatically fix 6 of these issues.
Run Psalm again with 
--alter --issues=MissingReturnType --dry-run
to see what it can fix.
------------------------------

Checks took 3.48 seconds and used 145.826MB of memory
Psalm was able to infer types for 88.6188% of the codebase
```