### PR TITLE
Ensure that state resetted by DI, even if event system doesn't trigger clear methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "symfony/dependency-injection": "^4.4|^5.4|^6.0",
     "symfony/event-dispatcher": "^4.4|^5.4|^6.0",
     "symfony/http-kernel": "^4.4|^5.4|^6.0",
-    "symfony/yaml": "^4.4|^5.4|^6.0"
+    "symfony/yaml": "^4.4|^5.4|^6.0",
+    "symfony/service-contracts": "^2|^3"
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/src/Bridge/BackgroundSpanHandler.php
+++ b/src/Bridge/BackgroundSpanHandler.php
@@ -12,8 +12,9 @@ use Jaeger\Symfony\Tag\SymfonyVersionTag;
 use Jaeger\Tag\SpanKindServerTag;
 use Jaeger\Tracer\TracerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Service\ResetInterface;
 
-class BackgroundSpanHandler
+class BackgroundSpanHandler implements ResetInterface
 {
     private ?SpanInterface $span = null;
 
@@ -47,8 +48,13 @@ class BackgroundSpanHandler
             return $this;
         }
         $this->span->finish();
-        $this->span = null;
+        $this->reset();
 
         return $this;
+    }
+
+    public function reset(): void
+    {
+        $this->span = null;
     }
 }

--- a/src/Bridge/MainSpanHandler.php
+++ b/src/Bridge/MainSpanHandler.php
@@ -12,8 +12,9 @@ use Jaeger\Symfony\Tag\SymfonyVersionTag;
 use Jaeger\Tag\SpanKindServerTag;
 use Jaeger\Tracer\TracerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Service\ResetInterface;
 
-class MainSpanHandler
+class MainSpanHandler implements ResetInterface
 {
     /**
      * @var Span
@@ -72,6 +73,12 @@ class MainSpanHandler
             return;
         }
         $this->span->finish((int)$this->durationUsec);
-        $this->span = $this->durationUsec = null;
+        $this->reset();
+    }
+
+    public function reset(): void
+    {
+        $this->span = null;
+        $this->durationUsec = null;
     }
 }

--- a/src/Context/Extractor/HeaderContextExtractor.php
+++ b/src/Context/Extractor/HeaderContextExtractor.php
@@ -10,8 +10,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Contracts\Service\ResetInterface;
 
-class HeaderContextExtractor implements ContextExtractorInterface, EventSubscriberInterface
+class HeaderContextExtractor implements ContextExtractorInterface, EventSubscriberInterface, ResetInterface
 {
     /**
      * @var CodecInterface[]
@@ -49,7 +50,8 @@ class HeaderContextExtractor implements ContextExtractorInterface, EventSubscrib
         if (false === $this->isMainRequestEvent($event)) {
             return;
         }
-        $this->context = null;
+
+        $this->reset();
     }
 
     public function onRequest(RequestEvent $event): void
@@ -78,5 +80,10 @@ class HeaderContextExtractor implements ContextExtractorInterface, EventSubscrib
         }
 
         return $event->isMasterRequest();
+    }
+
+    public function reset(): void
+    {
+        $this->context = null;
     }
 }

--- a/src/Debug/Extractor/CookieDebugExtractor.php
+++ b/src/Debug/Extractor/CookieDebugExtractor.php
@@ -7,8 +7,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Contracts\Service\ResetInterface;
 
-class CookieDebugExtractor implements DebugExtractorInterface, EventSubscriberInterface
+class CookieDebugExtractor implements DebugExtractorInterface, EventSubscriberInterface, ResetInterface
 {
     private $debugId = '';
 
@@ -36,6 +37,12 @@ class CookieDebugExtractor implements DebugExtractorInterface, EventSubscriberIn
         if (false === $this->isMainRequestEvent($event)) {
             return;
         }
+
+        $this->reset();
+    }
+
+    public function reset(): void
+    {
         $this->debugId = '';
     }
 

--- a/src/Debug/Extractor/EnvDebugExtractor.php
+++ b/src/Debug/Extractor/EnvDebugExtractor.php
@@ -5,8 +5,9 @@ namespace Jaeger\Symfony\Debug\Extractor;
 
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
-class EnvDebugExtractor implements DebugExtractorInterface, EventSubscriberInterface
+class EnvDebugExtractor implements DebugExtractorInterface, EventSubscriberInterface, ResetInterface
 {
     private $envName;
 
@@ -27,9 +28,14 @@ class EnvDebugExtractor implements DebugExtractorInterface, EventSubscriberInter
 
     public function onTerminate()
     {
-        $this->debugId = '';
+        $this->reset();
 
         return $this;
+    }
+
+    public function reset(): void
+    {
+        $this->debugId = '';
     }
 
     public function getDebug(): string

--- a/src/Name/Generator/ControllerNameGenerator.php
+++ b/src/Name/Generator/ControllerNameGenerator.php
@@ -6,8 +6,9 @@ namespace Jaeger\Symfony\Name\Generator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Contracts\Service\ResetInterface;
 
-class ControllerNameGenerator implements NameGeneratorInterface, EventSubscriberInterface
+class ControllerNameGenerator implements NameGeneratorInterface, EventSubscriberInterface, ResetInterface
 {
     private string $controller = '';
 
@@ -26,6 +27,11 @@ class ControllerNameGenerator implements NameGeneratorInterface, EventSubscriber
     }
 
     public function onTerminate(): void
+    {
+        $this->reset();
+    }
+
+    public function reset(): void
     {
         $this->controller = '';
     }

--- a/src/Name/Generator/DefaultNameGenerator.php
+++ b/src/Name/Generator/DefaultNameGenerator.php
@@ -8,8 +8,9 @@ use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Contracts\Service\ResetInterface;
 
-class DefaultNameGenerator implements NameGeneratorInterface, EventSubscriberInterface
+class DefaultNameGenerator implements NameGeneratorInterface, EventSubscriberInterface, ResetInterface
 {
     private string $name = '';
 
@@ -48,6 +49,11 @@ class DefaultNameGenerator implements NameGeneratorInterface, EventSubscriberInt
     }
 
     public function onTerminate(): void
+    {
+        $this->reset();
+    }
+
+    public function reset(): void
     {
         $this->name = '';
     }

--- a/src/Name/Generator/RequestNameGenerator.php
+++ b/src/Name/Generator/RequestNameGenerator.php
@@ -6,8 +6,9 @@ namespace Jaeger\Symfony\Name\Generator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Contracts\Service\ResetInterface;
 
-class RequestNameGenerator implements NameGeneratorInterface, EventSubscriberInterface
+class RequestNameGenerator implements NameGeneratorInterface, EventSubscriberInterface, ResetInterface
 {
     /**
      * @var NameGeneratorInterface[] Key - regexp, value - name generator
@@ -47,9 +48,14 @@ class RequestNameGenerator implements NameGeneratorInterface, EventSubscriberInt
 
     public function onTerminate(): RequestNameGenerator
     {
-        $this->route = '';
+        $this->reset();
 
         return $this;
+    }
+
+    public function reset(): void
+    {
+        $this->route = '';
     }
 
     public function generate(): string

--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -103,6 +103,7 @@ services:
     tags:
       - {name: 'kernel.event_subscriber' }
       - {name: 'jaeger.context.extractor'}
+      - {name: 'kernel.reset', method: 'reset'}
   jaeger.context.extractor.chain:
     class: Jaeger\Symfony\Context\Extractor\ContextExtractorChain
     arguments:
@@ -116,6 +117,7 @@ services:
     tags:
       - {name: 'kernel.event_subscriber' }
       - {name: 'jaeger.debug.extractor'}
+      - {name: 'kernel.reset', method: 'reset'}
   jaeger.debug.extractor.cookie:
     class: Jaeger\Symfony\Debug\Extractor\CookieDebugExtractor
     arguments:
@@ -123,6 +125,7 @@ services:
     tags:
       - {name: 'kernel.event_subscriber' }
       - {name: 'jaeger.debug.extractor'}
+      - {name: 'kernel.reset', method: 'reset'}
   jaeger.debug.extractor.chain:
     class: Jaeger\Symfony\Debug\Extractor\DebugExtractorChain
     arguments:
@@ -133,16 +136,19 @@ services:
     class: Jaeger\Symfony\Name\Generator\ControllerNameGenerator
     tags:
       - {name: 'kernel.event_subscriber' }
+      - {name: 'kernel.reset', method: 'reset'}
   jaeger.name.generator.default:
     class: Jaeger\Symfony\Name\Generator\DefaultNameGenerator
     tags:
       - {name: 'kernel.event_subscriber' }
       - {name: 'jaeger.name.generator', priority: -16384}
+      - {name: 'kernel.reset', method: 'reset'}
   jaeger.name.generator.request:
     class: Jaeger\Symfony\Name\Generator\RequestNameGenerator
     tags:
       - {name: 'kernel.event_subscriber' }
       - {name: 'jaeger.name.generator', priority: -1024}
+      - {name: 'kernel.reset', method: 'reset'}
   jaeger.name.generator.command:
     class: Jaeger\Symfony\Name\Generator\CommandNameGenerator
     tags:
@@ -157,9 +163,13 @@ services:
   jaeger.span.handler.background:
     class: Jaeger\Symfony\Bridge\BackgroundSpanHandler
     arguments: ['@jaeger.tracer']
+    tags:
+      - { name: 'kernel.reset', method: 'reset' }
   jaeger.span.handler.main:
     class: Jaeger\Symfony\Bridge\MainSpanHandler
     arguments: ['@jaeger.tracer', '@jaeger.name.generator']
+    tags:
+      - { name: 'kernel.reset', method: 'reset' }
   jaeger.span.handler.global: '@jaeger.span.handler.main'
   jaeger.debug.listener:
     class: Jaeger\Symfony\Bridge\DebugListener


### PR DESCRIPTION
:sparkles: Implement resetting state interfaces from `symfony/service…-contracts` and declare DI tags to ensure state resetted always, not only if event system properly handled it

----

When there is event subscribers for `kernel.terminate`, that have priority bigger than in listeners which called methods like a `flush` or other "reset"-like methods - the state won't be cleared between HTTP requests.

In our case, we found that the clearing mechanism was broken when we "forgot" to call a `$kernel->terminate()` method for "daemon" HTTP serving mode (for example, Swoole).

Implementing reset methods with proper `kernel.reset` tags will guarantee that state is cleared for services registered in DI between HTTP requests