### PR TITLE
:package: Avoid memory leaks - reset stateful request listener state

### DIFF
--- a/src/Bridge/RequestSpanListener.php
+++ b/src/Bridge/RequestSpanListener.php
@@ -100,4 +100,12 @@ class RequestSpanListener implements EventSubscriberInterface
 
         return $event->isMasterRequest();
     }
+
+    public function reset(): void
+    {
+        // make stack empty to avoid memory leaks
+        while (false === $this->spans->isEmpty()) {
+            $this->spans->pop();
+        }
+    }
 }

--- a/src/Resources/services.yml
+++ b/src/Resources/services.yml
@@ -192,12 +192,13 @@ services:
       - '@jaeger.name.generator'
       - '@jaeger.tracer'
     tags:
-      - {name: 'kernel.event_subscriber' }
+      - { name: 'kernel.event_subscriber' }
+      - { name: 'kernel.reset', method: 'reset' }
   jaeger.global.span.listener.lifecycle:
     class: Jaeger\Symfony\Bridge\MainSpanLifecycleListener
     arguments: ['@jaeger.span.handler.main']
     tags:
-      - {name: 'kernel.event_subscriber' }
+      - { name: 'kernel.event_subscriber' }
   jaeger.global.span.listener.name:
     class: Jaeger\Symfony\Bridge\MainSpanNameListener
     arguments: ['@jaeger.span.handler.main']


### PR DESCRIPTION
`RequestSpanListener`'s spans queue is always growing with every processed request, which creates a problem for runtime like Swoole.